### PR TITLE
Update ajax.js - more efficient $http retry

### DIFF
--- a/lib/ngapp/ajax.js
+++ b/lib/ngapp/ajax.js
@@ -36,20 +36,11 @@ angular.module('pancakesAngular')
                     config.retryTime = (new Date()).getTime();
 
                     var $http = $injector.get('$http');
-                    var deferred = $q.defer();
 
                     // do timeout to give some time in between retries
-                    $timeout(function () {
-                        $http(config)
-                            .then(function (respData) {
-                                deferred.resolve(respData);
-                            })
-                            .catch(function (respData) {
-                                deferred.reject(respData);
-                            });
-                    }, 200 * config.retryCount);
-
-                    return deferred.promise;
+                    return $timeout(function () {
+                        return $http(config);
+                    }, 200 * config.retryCount, false);
                 }
 
                 // give up


### PR DESCRIPTION
Remove redundant creation of deferred object. $timeout already returns a promise that will be resolved with the return value of the function provided as its first parameter; in this case the $http promise.

Set invokeApply parameter of $timeout to false as $http will already cause a $digest cycle to occur.
